### PR TITLE
Role name specific to bucket name

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -109,7 +109,7 @@ async function createOrUpdateS3ReplicationRole (
 
   const defaultRoleName = `${getServiceName(serverless)}-${sourceRegion}-${sourceBucket}-${REPLICATION_ROLE_SUFFIX}`
   const prefixOverride = serverless.service.custom.s3ReplicationPlugin.replicationRolePrefixOverride
-  const roleName = prefixOverride ? `${prefixOverride}-${sourceRegion}-${REPLICATION_ROLE_SUFFIX}` : defaultRoleName
+  const roleName = prefixOverride ? `${prefixOverride}-${sourceBucket}-${REPLICATION_ROLE_SUFFIX}` : defaultRoleName
 
   const createRoleRequest = {
     RoleName: roleName,

--- a/tests/helper.test.js
+++ b/tests/helper.test.js
@@ -384,8 +384,8 @@ test('test replication role with prefix override', async () => {
 
   expect(replicationConfigMap.size).toBe(2)
 
-  expect(replicationConfigMap.get('my-bucket-eu-west-1').role).toEqual(`${prefix}-eu-west-1-s3-rep-role`)
-  expect(replicationConfigMap.get('my-bucket-eu-central-1').role).toEqual(`${prefix}-eu-central-1-s3-rep-role`)
+  expect(replicationConfigMap.get('my-bucket-eu-west-1').role).toEqual(`${prefix}-my-bucket-eu-west-1-s3-rep-role`)
+  expect(replicationConfigMap.get('my-bucket-eu-central-1').role).toEqual(`${prefix}-my-bucket-eu-central-1-s3-rep-role`)
 })
 
 test('test with replication time control', async () => {


### PR DESCRIPTION
The previous name used the region which resulted with every bucket replication duo to override the others and the premissions didn't work.

We need a permission per bucket name