### PR TITLE
Feat - Add a config for short role name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,24 +1,33 @@
 # Serverless S3 replication plugin
+
 [![serverless](http://public.serverless.com/badges/v3.svg)](http://www.serverless.com)
 ![Coverage Status](https://raw.githubusercontent.com/stefmorren/serverless-s3-replication-plugin/main/coverage/badge.svg?branch=master)
 
-This is a serverless plugin to easily setup replications between AWS S3 buckets. The plugin allows you to set up single direction and/or bidirectional replication.
+This is a serverless plugin to easily setup replications between AWS S3 buckets. The plugin allows you to set up single
+direction and/or bidirectional replication.
 
-The plugin will wait until all buckets from the configuration exist. If they all succeed, the plugin will modify the configured S3 buckets and add replication to them. Also, the required IAM roles will automatically be created for you. The IAM role follows the best practice to only have the permissions to resources it really needs. There will be a unique IAM role in each region.   
+The plugin will wait until all buckets from the configuration exist. If they all succeed, the plugin will modify the
+configured S3 buckets and add replication to them. Also, the required IAM roles will automatically be created for you.
+The IAM role follows the best practice to only have the permissions to resources it really needs. There will be a unique
+IAM role in each region.
 
 ## Install
+
 `npm install --save-dev serverless-s3-replication-plugin`
 
 ## Usage
+
 1. Configure the plugin in your `serverless.yml`
 
 ```yaml
 plugins:
-- serverless-s3-replication-plugin
+  - serverless-s3-replication-plugin
 ```
+
 2. Add the configuration for the plugin
 
 2.1. Single direction replication example
+
 ```yaml
 custom:
   s3ReplicationPlugin:
@@ -35,6 +44,7 @@ custom:
 ```
 
 2.2. Bidirectional replication example
+
 ```yaml
 custom:
   s3ReplicationPlugin:
@@ -45,35 +55,6 @@ custom:
 ```
 
 2.3. Hybrid architecture with bidirectional and single direction replication
-```yaml
-custom:
-  s3ReplicationPlugin:
-    singleDirectionReplication:
-      - sourceBucket: 
-          eu-west-1: my-bucket-jlsadjklsd-eu-west-1
-        targetBuckets: 
-          - eu-west-2: my-bucket-jlsadjklsd-eu-west-2
-          - eu-west-1: my-bucket-jlsadjklsd-sec-eu-west-1
-      - sourceBucket: 
-          eu-central-1: my-bucket-jlsadjklsd-eu-central-1
-        targetBuckets: 
-          - eu-west-1: my-bucket-jlsadjklsd-eu-west-1
-    bidirectionalReplicationBuckets:
-      - eu-west-1: my-bucket-jlsadjklsd-eu-west-1
-      - eu-central-1: my-bucket-jlsadjklsd-eu-central-1
-      - us-east-1: my-bucket-jlsadjklsd-us-east-1
-```
-
-## Overriding the S3 Replication Role name
-The default value of the Replication Role is: `${serviceName}-${sourceRegion}-${sourceBucket}-s3-rep-role`. 
-In most cases this default value will work without issue. But if your `serviceName` or `sourceBucket` are long, the cloudformation stack will fail with an error similar to:
-
-```
-Error:
-ValidationError: 1 validation error detected: Value 'your-long-service-name-eu-west-1-your-long-s3-bucket-name-s3-rep-role' at 'roleName' failed to satisfy constraint: Member must have length less than or equal to 64
-```
-
-To resolve this issue, you can use the `replicationRolePrefixOverride` configuration to set a default prefix value, which will use the following format: `${replicationRolePrefixOverride}-${sourceRegion}-s3-rep-role`.
 
 ```yaml
 custom:
@@ -84,16 +65,52 @@ custom:
         targetBuckets:
           - eu-west-2: my-bucket-jlsadjklsd-eu-west-2
           - eu-west-1: my-bucket-jlsadjklsd-sec-eu-west-1
-    replicationRolePrefixOverride: "my-prefix"
+      - sourceBucket:
+          eu-central-1: my-bucket-jlsadjklsd-eu-central-1
+        targetBuckets:
+          - eu-west-1: my-bucket-jlsadjklsd-eu-west-1
+    bidirectionalReplicationBuckets:
+      - eu-west-1: my-bucket-jlsadjklsd-eu-west-1
+      - eu-central-1: my-bucket-jlsadjklsd-eu-central-1
+      - us-east-1: my-bucket-jlsadjklsd-us-east-1
+```
+
+## Overriding the S3 Replication Role name
+
+The default value of the Replication Role is: `${serviceName}-${sourceRegion}-${sourceBucket}-s3-rep-role`.
+In most cases this default value will work without issue. But if your `serviceName` or `sourceBucket` are long, the
+cloudformation stack will fail with an error similar to:
+
+```
+Error:
+ValidationError: 1 validation error detected: Value 'your-long-service-name-eu-west-1-your-long-s3-bucket-name-s3-rep-role' at 'roleName' failed to satisfy constraint: Member must have length less than or equal to 64
+```
+
+To resolve this issue, you can use the `useShortRoleName` configuration to to reduce the length of the role name to the
+format - `${sourceBucket}-s3-rep-role`.
+
+```yaml
+custom:
+  s3ReplicationPlugin:
+    singleDirectionReplication:
+      - sourceBucket:
+          eu-west-1: my-bucket-jlsadjklsd-eu-west-1
+        targetBuckets:
+          - eu-west-2: my-bucket-jlsadjklsd-eu-west-2
+          - eu-west-1: my-bucket-jlsadjklsd-sec-eu-west-1
+    useShortRoleName: true
 ```
 
 This will result in the following replication role names:
+
 - `my-prefix-eu-west-1-s3-rep-role`
 - `my-prefix-eu-west-2-s3-rep-role`
 
 ## Setting Replication Time Control
+
 The default value is disabled.
-To enable it, you can use the `withReplicationTimeControl` configuration, set it to true to enable replication time control.
+To enable it, you can use the `withReplicationTimeControl` configuration, set it to true to enable replication time
+control.
 
 ```yaml
 custom:

--- a/src/helper.js
+++ b/src/helper.js
@@ -107,9 +107,9 @@ async function createOrUpdateS3ReplicationRole (
 ) {
   const iam = new aws.IAM(getCredentials(serverless))
 
-  const defaultRoleName = `${getServiceName(serverless)}-${sourceRegion}-${sourceBucket}-${REPLICATION_ROLE_SUFFIX}`
-  const prefixOverride = serverless.service.custom.s3ReplicationPlugin.replicationRolePrefixOverride
-  const roleName = prefixOverride ? `${prefixOverride}-${sourceBucket}-${REPLICATION_ROLE_SUFFIX}` : defaultRoleName
+  const roleName = serverless.service.custom.s3ReplicationPlugin.useShortRoleName ?
+    `${sourceBucket}-${REPLICATION_ROLE_SUFFIX}` :
+    `${getServiceName(serverless)}-${sourceRegion}-${sourceBucket}-${REPLICATION_ROLE_SUFFIX}`
 
   const createRoleRequest = {
     RoleName: roleName,

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ class S3ReplicationPlugin {
           properties: {
             singleDirectionReplication: { type: 'array' },
             bidirectionalReplicationBuckets: { type: 'array' },
-            replicationRolePrefixOverride: { type: 'string' },
+            useShortRoleName: { type: 'boolean' },
             withReplicationTimeControl: { type: 'boolean' }
           }
         }

--- a/tests/helper.test.js
+++ b/tests/helper.test.js
@@ -379,13 +379,12 @@ test('test hybrid model of single direction and bidirectional s3 replication', a
 })
 
 test('test replication role with prefix override', async () => {
-  const prefix = 'my-prefix'
-  const replicationConfigMap = await helper.setupS3Replication(createServerlessContext(true, false, prefix))
+  const replicationConfigMap = await helper.setupS3Replication(createServerlessContext(true, false, true))
 
   expect(replicationConfigMap.size).toBe(2)
 
-  expect(replicationConfigMap.get('my-bucket-eu-west-1').role).toEqual(`${prefix}-my-bucket-eu-west-1-s3-rep-role`)
-  expect(replicationConfigMap.get('my-bucket-eu-central-1').role).toEqual(`${prefix}-my-bucket-eu-central-1-s3-rep-role`)
+  expect(replicationConfigMap.get('my-bucket-eu-west-1').role).toEqual(`my-bucket-eu-west-1-s3-rep-role`)
+  expect(replicationConfigMap.get('my-bucket-eu-central-1').role).toEqual(`my-bucket-eu-central-1-s3-rep-role`)
 })
 
 test('test with replication time control', async () => {
@@ -492,7 +491,7 @@ test('test with replication time control', async () => {
 
 })
 
-function createServerlessContext (singleDirection, bidirectional, replicationRolePrefixOverride, withReplicationTimeControl) {
+function createServerlessContext (singleDirection, bidirectional, useShortRoleName, withReplicationTimeControl) {
   return {
     service: {
       provider: {
@@ -503,7 +502,7 @@ function createServerlessContext (singleDirection, bidirectional, replicationRol
         s3ReplicationPlugin: {
           singleDirectionReplication: singleDirection ? createSingleDirectionReplicationConfig() : undefined,
           bidirectionalReplicationBuckets: bidirectional ? createBidirectionalReplicationConfig() : undefined,
-          replicationRolePrefixOverride,
+          useShortRoleName,
           withReplicationTimeControl
         }
       }


### PR DESCRIPTION
Use a much shorter role name to avoid hitting the limit, no need for the prefix as it was