### PR TITLE
Chore: add sleep prevent rate exceeded

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -247,7 +247,7 @@ function createS3RulesForBucket (serverless, sourceBucket, targetBucketConfigs, 
       }
     })
 
-    counter+
+    counter++
 
     serverless.cli.log(`${LOG_PREFIX} Creating replication rule between ${chalk.green(sourceBucket)} and ${chalk.green(targetBucket)} S3 buckets`)
   }

--- a/src/helper.js
+++ b/src/helper.js
@@ -5,6 +5,9 @@ const S3_PREFIX = 'arn:aws:s3:::'
 const TAG = 'SLS-S3-REPLICATION-PLUGIN'
 const LOG_PREFIX = 'SLS-S3-REPLICATION-PLUGIN:'
 const REPLICATION_ROLE_SUFFIX = 's3rep'
+const SLEEP_TIME = 2000
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function getCredentials (serverless) {
   const provider = serverless.getProvider('aws')
@@ -210,6 +213,7 @@ async function putBucketReplicationsForReplicationConfigMap (serverless, replica
     }
 
     await s3.putBucketReplication(s3BucketReplicationRequest).promise()
+    await sleep(SLEEP_TIME);
   }
 }
 
@@ -243,7 +247,7 @@ function createS3RulesForBucket (serverless, sourceBucket, targetBucketConfigs, 
       }
     })
 
-    counter++
+    counter+
 
     serverless.cli.log(`${LOG_PREFIX} Creating replication rule between ${chalk.green(sourceBucket)} and ${chalk.green(targetBucket)} S3 buckets`)
   }


### PR DESCRIPTION
Try doing it with 2 sec sleep, to prevent rate-exceeded
```
Starting setup of single direction replication
SLS-S3-REPLICATION-PLUGIN: Creating replication rule between shared-prod-environment-state-bucket-us-west-2 and shared-prod-environment-state-bucket S3 buckets
SLS-S3-REPLICATION-PLUGIN: Creating replication rule between shared-prod-environment-state-bucket and shared-prod-environment-state-bucket-us-west-2 S3 buckets
SLS-S3-REPLICATION-PLUGIN: Creating replication rule between shared-prod-agent-working-directory-bucket-us-west-2 and shared-prod-agent-working-directory-bucket S3 buckets
SLS-S3-REPLICATION-PLUGIN: Creating replication rule between shared-prod-agent-working-directory-bucket and shared-prod-agent-working-directory-bucket-us-west-2 S3 buckets
SLS-S3-REPLICATION-PLUGIN: Creating replication rule between shared-prod-http-proxy-response-us-west-2 and shared-prod-http-proxy-response S3 buckets
SLS-S3-REPLICATION-PLUGIN: Creating replication rule between shared-prod-http-proxy-response and shared-prod-http-proxy-response-us-west-2 S3 buckets
SLS-S3-REPLICATION-PLUGIN: Creating replication rule between shared-prod-workflow-environments-request-bucket-us-west-2 and shared-prod-workflow-environments-request-bucket S3 buckets
SLS-S3-REPLICATION-PLUGIN: Creating replication rule between shared-prod-workflow-environments-request-bucket and shared-prod-workflow-environments-request-bucket-us-west-2 S3 buckets
SLS-S3-REPLICATION-PLUGIN: Creating replication rule between shared-prod-sentry-error-images-bucket-us-west-2 and shared-prod-sentry-error-images-bucket S3 buckets
SLS-S3-REPLICATION-PLUGIN: Creating replication rule between shared-prod-sentry-error-images-bucket and shared-prod-sentry-error-images-bucket-us-west-2 S3 buckets
SLS-S3-REPLICATION-PLUGIN: Creating replication rule between shared-prod-state-versions-us-west-2 and shared-prod-state-versions S3 buckets
SLS-S3-REPLICATION-PLUGIN: Creating replication rule between shared-prod-state-versions and shared-prod-state-versions-us-west-2 S3 buckets
SLS-S3-REPLICATION-PLUGIN: Creating replication rule between shared-prod-configuration-versions-us-west-2 and shared-prod-configuration-versions S3 buckets
SLS-S3-REPLICATION-PLUGIN: Creating replication rule between shared-prod-configuration-versions and shared-prod-configuration-versions-us-west-2 S3 buckets
× Stack shared-prod failed to deploy (33s)
Environment: linux, node 18.16.1, framework 3.38.0 (local) 3.38.0v (global), plugin 7.2.0, SDK 4.5.1
Credentials: Local, environment variables
Docs:        docs.serverless.com
Support:     forum.serverless.com
Bugs:        github.com/serverless/serverless/issues
Error:
Throttling: Rate exceeded
```